### PR TITLE
added usage of TMUX_BIN

### DIFF
--- a/packet-loss.tmux
+++ b/packet-loss.tmux
@@ -7,7 +7,7 @@
 #
 #   Part of https://github.com/jaclu/tmux-packet-loss
 #
-#   Version: 0.2.0 2022-09-12
+#   Version: 0.2.1 2022-09-15
 #
 #   This is the coordination script
 #    - ensures the database is present and up to date
@@ -131,7 +131,7 @@ hook_handler() {
     local tmux_vers
     local hook_name
 
-    tmux_vers="$(tmux -V | cut -d' ' -f2)"
+    tmux_vers="$($TMUX_BIN -V | cut -d' ' -f2)"
     log_it "hook_handler($action) tmux vers: $tmux_vers"
 
     # needed to be able to handle versions like 3.2a
@@ -147,10 +147,10 @@ hook_handler() {
     fi
     if [ -n "$hook_name" ]; then
         if [ "$action" = "set" ]; then
-            tmux set-hook -g "$hook_name" "run $no_sessions_shutdown_full_name"
+            $TMUX_BIN set-hook -g "$hook_name" "run $no_sessions_shutdown_full_name"
             log_it "binding packet-loss shutdown to: $hook_name"
         elif [ "$action" = "clear" ]; then
-            tmux set-hook -ug "$hook_name"
+            $TMUX_BIN set-hook -ug "$hook_name"
             log_it "releasing hook: $hook_name"
         else
             error_msg "hook_handler must be called with param set or clear!" 1
@@ -213,7 +213,7 @@ set_tmux_option() {
     local option="$1"
     local value="$2"
 
-    tmux set-option -gq "$option" "$value"
+    $TMUX_BIN set-option -gq "$option" "$value"
 }
 
 

--- a/scripts/shutdown_if_no_sessions.sh
+++ b/scripts/shutdown_if_no_sessions.sh
@@ -5,7 +5,7 @@
 #
 #   Part of https://github.com/jaclu/tmux-packet-loss
 #
-#   Version: 0.1.0 2022-03-25
+#   Version: 0.1.1 2022-09-15
 #
 #  If no more sessions are running, terminate background packet loss processes
 #
@@ -17,7 +17,7 @@ PARRENT_DIR="$(dirname -- "$CURRENT_DIR")"
 . "$CURRENT_DIR/utils.sh"
 
 
-ses_count="$(tmux ls | wc -l)"
+ses_count="$($TMUX_BIN ls | wc -l)"
 
 # shellcheck disable=SC2154
 log_it "$no_sessions_shutdown_scr - session count [$ses_count]"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -8,7 +8,7 @@
 #
 #   Part of https://github.com/jaclu/tmux-packet-loss
 #
-#   Version: 0.2.2 2022-03-31
+#   Version: 0.2.3 2022-09-15
 #
 #  Common stuff
 #
@@ -18,6 +18,17 @@
 #  locations, easily getting out of sync.
 #
 plugin_name="tmux-packet-loss"
+
+
+#
+#  I use an env var TMUX_BIN to point at the current tmux, defined in my
+#  tmux.conf, in order to pick the version matching the server running.
+#  This is needed when checking backwards compatability with various versions.
+#  If not found, it is set to whatever is in path, so should have no negative
+#  impact. In all calls to tmux I use $TMUX_BIN instead in the rest of this
+#  plugin.
+#
+[ -z "$TMUX_BIN" ] && TMUX_BIN="tmux"
 
 
 #
@@ -80,7 +91,7 @@ log_it() {
 get_tmux_option() {
     gtm_option=$1
     gtm_default=$2
-    gtm_value="$(tmux show-option -gqv "$gtm_option")"
+    gtm_value="$($TMUX_BIN show-option -gqv "$gtm_option")"
     if [ -z "$gtm_value" ]; then
         echo "$gtm_default"
     else
@@ -101,7 +112,7 @@ error_msg() {
     exit_code="${2:-0}"
 
     log_it "$msg"
-    tmux display-message "$plugin_name $msg"
+    $TMUX_BIN display-message "$plugin_name $msg"
     [ "$exit_code" -ne 0 ] && exit "$exit_code"
 }
 


### PR DESCRIPTION
In order to be able to test various versions of tmux for compatibility with plugins, I used ASDF.
This has the drawback of using ~/.asdf/shims/tmux thus not allowing the path to tmux itself to identify what tmux to run, so I have set up my tmux.conf to identify the actual tmux in that case. When using ASDF the actual path to tmux (example: ~/.asdf/installs/tmux/2.8/bin/tmux) is identified and stored in the env variable TMUX_BIN

Using $TMUX_BIN whenever the plugin needs to access tmux from the shell, ensures that the plugin uses the tmux associated with the running session. This makes my testing much more convenient since I don't have to kill my main tmux each time I want to test a specific version, I just run a separate tmux under the version being tested.
This should not have any impact if TMUX_BIN is not used, since then it defaults to just being 'tmux'